### PR TITLE
Fix exported function to a package of local on unix

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -61,10 +61,10 @@ func (tty *TTY) size() (int, int, error) {
 	return int(dim[1]), int(dim[0]), nil
 }
 
-func (tty *TTY) Input() *os.File {
+func (tty *TTY) input() *os.File {
 	return tty.in
 }
 
-func (tty *TTY) Output() *os.File {
+func (tty *TTY) output() *os.File {
 	return tty.out
 }


### PR DESCRIPTION
Currently, can not build any package that depends on `go-tty` on unix.
So, I was fixed exported function to a package of local.