### PR TITLE
Added Plan 9 support.

### DIFF
--- a/tty_plan9.go
+++ b/tty_plan9.go
@@ -1,0 +1,58 @@
+package tty
+
+import (
+	"bufio"
+	"os"
+	"syscall"
+)
+
+type TTY struct {
+	in  *os.File
+	out *os.File
+}
+
+func open() (*TTY, error) {
+	tty := new(TTY)
+
+	in, err := os.Open("/dev/cons")
+	if err != nil {
+		return nil, err
+	}
+	tty.in = in
+
+	out, err := os.OpenFile("/dev/cons", syscall.O_WRONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	tty.out = out
+
+	return tty, nil
+}
+
+func (tty *TTY) readRune() (rune, error) {
+	in := bufio.NewReader(tty.in)
+	r, _, err := in.ReadRune()
+	return r, err
+}
+
+func (tty *TTY) close() (err error) {
+	if err2 := tty.in.Close(); err2 != nil {
+		err = err2
+	}
+	if err2 := tty.out.Close(); err2 != nil {
+		err = err2
+	}
+	return
+}
+
+func (tty *TTY) size() (int, int, error) {
+	return 80, 24, nil
+}
+
+func (tty *TTY) input() *os.File {
+	return tty.in
+}
+
+func (tty *TTY) output() *os.File {
+	return tty.out
+}

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,4 +1,5 @@
 // +build !windows
+// +build !plan9
 
 package tty
 


### PR DESCRIPTION
This fixes build errors on Plan 9, by making a version
of tty_unix which is almost exactly the same, except
uses /dev/cons instead of /dev/tty and doesn't include
any of the termios calls.