### PR TITLE
The search dialog is open by pressing Ctrl-F on Windows10

### DIFF
--- a/tty_windows.go
+++ b/tty_windows.go
@@ -143,11 +143,12 @@ func open() (*TTY, error) {
 	if false && isatty.IsTerminal(os.Stdin.Fd()) {
 		tty.in = os.Stdin
 	} else {
-		conin, err := os.Open("CONIN$")
+		in, err := syscall.Open("CONIN$", syscall.O_RDWR, 0)
 		if err != nil {
 			return nil, err
 		}
-		tty.in = conin
+
+		tty.in = os.NewFile(uintptr(in), "/dev/tty")
 	}
 
 	if isatty.IsTerminal(os.Stdout.Fd()) {
@@ -177,7 +178,7 @@ func open() (*TTY, error) {
 	st &^= enableWindowInput
 	st &^= enableExtendedFlag
 	st &^= enableQuickEditMode
-	st |= enableProcessedInput
+	st &^= enableProcessedInput
 
 	// ignore error
 	procSetConsoleMode.Call(h, uintptr(st))


### PR DESCRIPTION
When Ctrl-F is pressed, this dialog is open on **Windows10 only**. 
(On Windows7 in my office, it is not open = no problems are found.)

![image](https://user-images.githubusercontent.com/3752189/49023530-c0866d80-f1da-11e8-8ad0-a7263066961a.png)

I found these.

- `SetConsoleMode` does not work when the handle for CONIO$ is open as RDONLY.
- When `enableProcessedInput` is set, Ctrl-F opens the dialog.

I made the patch and it works as expected on my PCs.

If you see the problem I found and the patch works as expected on your environments , would you consider to merge ?