### PR TITLE
[windows] don't enable processed input to still be able to receive interrupt signals

### DIFF
--- a/tty_windows.go
+++ b/tty_windows.go
@@ -178,7 +178,6 @@ func open() (*TTY, error) {
 	st &^= enableWindowInput
 	st &^= enableExtendedFlag
 	st &^= enableQuickEditMode
-	st &^= enableProcessedInput
 
 	// ignore error
 	procSetConsoleMode.Call(h, uintptr(st))


### PR DESCRIPTION
this fixes #11

also, here are some docs: https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals

related: https://github.com/mattn/go-tty/pull/10