### PR TITLE
Fix: tty-mode could not be changed from raw-mode to cooked-mode on Linux

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -105,6 +105,7 @@ func (tty *TTY) raw() (func() error, error) {
 	if err != nil {
 		return nil, err
 	}
+	backup := *termios
 
 	termios.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
 	termios.Oflag &^= unix.OPOST
@@ -118,7 +119,7 @@ func (tty *TTY) raw() (func() error, error) {
 	}
 
 	return func() error {
-		if err := unix.IoctlSetTermios(int(tty.in.Fd()), ioctlWriteTermios, termios); err != nil {
+		if err := unix.IoctlSetTermios(int(tty.in.Fd()), ioctlWriteTermios, &backup); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
for (Linux) tty-mode can not be switched from raw-mode to cooked-mode #13

Screen shot after my patch :

![image](https://user-images.githubusercontent.com/3752189/54580497-b1f2e900-4a4b-11e9-9925-e757fff01358.png)
