### PR TITLE
prevent `panic: send on closed channel` during termination

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -52,6 +52,7 @@ func open() (*TTY, error) {
 	tty.ss = make(chan os.Signal, 1)
 	signal.Notify(tty.ss, syscall.SIGWINCH)
 	go func() {
+		defer close(tty.ws)
 		for sig := range tty.ss {
 			switch sig {
 			case syscall.SIGWINCH:
@@ -79,7 +80,6 @@ func (tty *TTY) readRune() (rune, error) {
 
 func (tty *TTY) close() error {
 	close(tty.ss)
-	close(tty.ws)
 	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(tty.in.Fd()), ioctlWriteTermios, uintptr(unsafe.Pointer(&tty.termios)), 0, 0, 0)
 	return err
 }


### PR DESCRIPTION
sometimes it's possible to receive a SIGWINCH right in between when `close(tty.ss)` and `close(tty.ws)` are being called, causing a panic.

Making the `WINSIZE` production goroutine close the chan will prevent this.