### PR TITLE
prevent TUI crash on SIGWINCH

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -78,6 +78,7 @@ func (tty *TTY) readRune() (rune, error) {
 }
 
 func (tty *TTY) close() error {
+	signal.Stop(tty.ss)
 	close(tty.ss)
 	close(tty.ws)
 	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(tty.in.Fd()), ioctlWriteTermios, uintptr(unsafe.Pointer(&tty.termios)), 0, 0, 0)


### PR DESCRIPTION
One of my text user interface projects did start to crash on resizing the terminal emulator window.
"Wessie" from #go-nuts suggested this change.

Test program for reproducing the crash: [main.go.txt](https://github.com/mattn/go-tty/files/2998794/main.go.txt)



It works together with PR #15.