### PR TITLE
added function for getting terminal size in pixels

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -35,7 +35,12 @@ func (tty *TTY) Close() error {
 }
 
 func (tty *TTY) Size() (int, int, error) {
-	return tty.size()
+	x, y, err := tty.size()
+	return x, y, err
+}
+
+func (tty *TTY) SizePixel() (int, int, int, int, error) {
+	return tty.sizePixel()
 }
 
 func (tty *TTY) Input() *os.File {

--- a/tty.go
+++ b/tty.go
@@ -35,8 +35,7 @@ func (tty *TTY) Close() error {
 }
 
 func (tty *TTY) Size() (int, int, error) {
-	x, y, err := tty.size()
-	return x, y, err
+	return tty.size()
 }
 
 func (tty *TTY) SizePixel() (int, int, int, int, error) {

--- a/tty_plan9.go
+++ b/tty_plan9.go
@@ -57,7 +57,7 @@ func (tty *TTY) size() (int, int, error) {
 
 func (tty *TTY) sizePixel() (int, int, int, int, error) {
 	x, y, _ := tty.size()
-	return x, y, -1, -1, errors.New("no implemented method for querying size in pixels on Windows")
+	return x, y, -1, -1, errors.New("no implemented method for querying size in pixels on Plan 9")
 }
 
 func (tty *TTY) input() *os.File {

--- a/tty_plan9.go
+++ b/tty_plan9.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 	"errors"
 )
-s
+
 type TTY struct {
 	in  *os.File
 	bin *bufio.Reader

--- a/tty_plan9.go
+++ b/tty_plan9.go
@@ -4,8 +4,9 @@ import (
 	"bufio"
 	"os"
 	"syscall"
+	"errors"
 )
-
+s
 type TTY struct {
 	in  *os.File
 	bin *bufio.Reader
@@ -52,6 +53,11 @@ func (tty *TTY) close() (err error) {
 
 func (tty *TTY) size() (int, int, error) {
 	return 80, 24, nil
+}
+
+func (tty *TTY) sizePixel() (int, int, int, int, error) {
+	x, y, _ := tty.size()
+	return x, y, -1, -1, errors.New("no implemented method for querying size in pixels on Windows")
 }
 
 func (tty *TTY) input() *os.File {

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -86,11 +86,16 @@ func (tty *TTY) close() error {
 }
 
 func (tty *TTY) size() (int, int, error) {
+	x, y, _, _, err := tty.sizePixel()
+	return x, y, err
+}
+
+func (tty *TTY) sizePixel() (int, int, int, int, error) {
 	var dim [4]uint16
 	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(tty.out.Fd()), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&dim)), 0, 0, 0); err != 0 {
-		return -1, -1, err
+		return -1, -1, -1, -1, err
 	}
-	return int(dim[1]), int(dim[0]), nil
+	return int(dim[1]), int(dim[0]), int(dim[2]), int(dim[3]), nil
 }
 
 func (tty *TTY) input() *os.File {

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -4,6 +4,7 @@ package tty
 
 import (
 	"os"
+	"errors"
 	"syscall"
 	"unsafe"
 
@@ -285,9 +286,18 @@ func (tty *TTY) size() (int, int, error) {
 	var csbi consoleScreenBufferInfo
 	r1, _, err := procGetConsoleScreenBufferInfo.Call(tty.out.Fd(), uintptr(unsafe.Pointer(&csbi)))
 	if r1 == 0 {
-		return 0, 0, err
+			return 0, 0, err
 	}
 	return int(csbi.window.right - csbi.window.left + 1), int(csbi.window.bottom - csbi.window.top + 1), nil
+}
+
+func (tty *TTY) sizePixel() (int, int, int, int, error) {
+	x, y, err := tty.size()
+	if err != nil {
+		x = -1
+		y = -1
+	}
+	return x, y, -1, -1, errors.New("no implemented method for querying size in pixels on Windows")
 }
 
 func (tty *TTY) input() *os.File {

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -286,7 +286,7 @@ func (tty *TTY) size() (int, int, error) {
 	var csbi consoleScreenBufferInfo
 	r1, _, err := procGetConsoleScreenBufferInfo.Call(tty.out.Fd(), uintptr(unsafe.Pointer(&csbi)))
 	if r1 == 0 {
-			return 0, 0, err
+		return 0, 0, err
 	}
 	return int(csbi.window.right - csbi.window.left + 1), int(csbi.window.bottom - csbi.window.top + 1), nil
 }


### PR DESCRIPTION
added function SizePixel() int, int, int, int, error for getting terminal size in pixels. The first, second and fifth return value are the same as the ones from Size() with the addition of the third and fourth being the terminal size in pixels.

The size() function for Unix already gets those values but disregards them. I would like to change this. For Windows and Plan 9 the values are set to -1 and an error would be returned.

The change would make go-tty more useful for usage in combination with sixel graphics.

This is only a suggestion for https://github.com/mattn/go-tty/issues/18.