### PR TITLE
Support Ctrl-Left/Right/Up/Down on Windows keeping compatiblity with Linux

### DIFF
--- a/_example/simple.go
+++ b/_example/simple.go
@@ -22,6 +22,12 @@ func main() {
 		}
 	}()
 
+	clean,err := t.Raw()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer clean()
+
 	fmt.Println("Hit any key")
 	for {
 		r, err := t.ReadRune()

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -228,6 +228,22 @@ func (tty *TTY) readRune() (rune, error) {
 				return rune(kr.unicodeChar), nil
 			}
 			vk := kr.virtualKeyCode
+			if kr.controlKeyState&ctrlPressed != 0 {
+				switch vk {
+				case 0x25: // ctrl-left
+					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x44}
+					return rune(0x1b), nil
+				case 0x26: // ctrl-up
+					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x41}
+					return rune(0x1b), nil
+				case 0x27: // ctrl-right
+					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x43}
+					return rune(0x1b), nil
+				case 0x28: // ctrl-down
+					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x42}
+					return rune(0x1b), nil
+				}
+			}
 			switch vk {
 			case 0x21: // page-up
 				tty.rs = []rune{0x5b, 0x35, 0x7e}

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -230,6 +230,18 @@ func (tty *TTY) readRune() (rune, error) {
 			vk := kr.virtualKeyCode
 			if kr.controlKeyState&ctrlPressed != 0 {
 				switch vk {
+				case 0x21: // ctrl-page-up
+					tty.rs = []rune{0x5b, 0x35, 0x3B, 0x35, 0x7e}
+					return rune(0x1b), nil
+				case 0x22: // ctrl-page-down
+					tty.rs = []rune{0x5b, 0x36, 0x3B, 0x35, 0x7e}
+					return rune(0x1b), nil
+				case 0x23: // ctrl-end
+					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x46}
+					return rune(0x1b), nil
+				case 0x24: // ctrl-home
+					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x48}
+					return rune(0x1b), nil
 				case 0x25: // ctrl-left
 					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x44}
 					return rune(0x1b), nil
@@ -241,6 +253,9 @@ func (tty *TTY) readRune() (rune, error) {
 					return rune(0x1b), nil
 				case 0x28: // ctrl-down
 					tty.rs = []rune{0x5b, 0x31, 0x3B, 0x35, 0x42}
+					return rune(0x1b), nil
+				case 0x2e: // ctrl-delete
+					tty.rs = []rune{0x5b, 0x33, 0x3B, 0x35, 0x7e}
 					return rune(0x1b), nil
 				}
 			}


### PR DESCRIPTION
On Windows, ReadRune() could not catch Ctrl-UP/DOWN/RIGHT/LEFT, but on Linux it can.

With this patch, ReadRune() on Windows can catch them as below.

- Ctrl-UP : `^[[1;5A`
- Ctrl-DOWN: `^[[1;5B`
- Ctrl-LEFT: `^[[1;5D`
- Ctrl-RIGHT: `^[[1;5C`

Would you merge my patch if there is no problem ?

(I fixed _example/simple.go because under cooked-mode, Ctrl-DOWN and Ctrl-UP work to scroll the console-window  )




