### PR TITLE
fix panic: send on closed channel on windows

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -115,6 +115,6 @@ type WINSIZE struct {
 	H int
 }
 
-func (tty *TTY) SIGWINCH() chan WINSIZE {
+func (tty *TTY) SIGWINCH() <-chan WINSIZE {
 	return tty.sigwinch()
 }

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -127,6 +127,6 @@ func (tty *TTY) raw() (func() error, error) {
 	}, nil
 }
 
-func (tty *TTY) sigwinch() chan WINSIZE {
 	return tty.ws
+func (tty *TTY) sigwinch() <-chan WINSIZE {
 }

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -18,7 +18,6 @@ type TTY struct {
 	bin     *bufio.Reader
 	out     *os.File
 	termios syscall.Termios
-	ws      chan WINSIZE
 	ss      chan os.Signal
 }
 
@@ -48,24 +47,8 @@ func open() (*TTY, error) {
 		return nil, err
 	}
 
-	tty.ws = make(chan WINSIZE)
 	tty.ss = make(chan os.Signal, 1)
-	signal.Notify(tty.ss, syscall.SIGWINCH)
-	go func() {
-		defer close(tty.ws)
-		for sig := range tty.ss {
-			switch sig {
-			case syscall.SIGWINCH:
-				if w, h, err := tty.size(); err == nil {
-					tty.ws <- WINSIZE{
-						W: w,
-						H: h,
-					}
-				}
-			default:
-			}
-		}
-	}()
+
 	return tty, nil
 }
 
@@ -127,6 +110,28 @@ func (tty *TTY) raw() (func() error, error) {
 	}, nil
 }
 
-	return tty.ws
 func (tty *TTY) sigwinch() <-chan WINSIZE {
+	signal.Notify(tty.ss, syscall.SIGWINCH)
+
+	ws := make(chan WINSIZE)
+	go func() {
+		defer close(ws)
+		for sig := range tty.ss {
+			if sig != syscall.SIGWINCH {
+				continue
+			}
+
+			w, h, err := tty.size()
+			if err != nil {
+				continue
+			}
+			// send but do not block for it
+			select {
+			case ws <- WINSIZE{W: w, H: h}:
+			default:
+			}
+
+		}
+	}()
+	return ws
 }

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -3,6 +3,7 @@
 package tty
 
 import (
+	"context"
 	"os"
 	"syscall"
 	"unsafe"
@@ -122,12 +123,13 @@ type charInfo struct {
 }
 
 type TTY struct {
-	in     *os.File
-	out    *os.File
-	st     uint32
-	rs     []rune
-	ws     chan WINSIZE
-	closeC chan interface{}
+	in                *os.File
+	out               *os.File
+	st                uint32
+	rs                []rune
+	ws                chan WINSIZE
+	sigwinchCtx       context.Context
+	sigwinchCtxCancel context.CancelFunc
 }
 
 func readConsoleInput(fd uintptr, record *inputRecord) (err error) {
@@ -184,7 +186,7 @@ func open() (*TTY, error) {
 	procSetConsoleMode.Call(h, uintptr(st))
 
 	tty.ws = make(chan WINSIZE)
-	tty.closeC = make(chan interface{})
+	tty.sigwinchCtx, tty.sigwinchCtxCancel = context.WithCancel(context.Background())
 
 	return tty, nil
 }
@@ -212,13 +214,17 @@ func (tty *TTY) readRune() (rune, error) {
 			W: int(wr.size.x),
 			H: int(wr.size.y),
 		}
-		select {
-		case <-tty.closeC: // closing
-			return 0, nil
-		default:
+
+		if err := tty.sigwinchCtx.Err(); err != nil {
+			// closing
+			// the following select might panic without this guard close
+			return 0, err
 		}
+
 		select {
 		case tty.ws <- ws:
+		case <-tty.sigwinchCtx.Done():
+			return 0, tty.sigwinchCtx.Err()
 		default:
 			return 0, nil // no one is currently trying to read
 		}
@@ -320,7 +326,7 @@ func (tty *TTY) readRune() (rune, error) {
 
 func (tty *TTY) close() error {
 	procSetConsoleMode.Call(tty.in.Fd(), uintptr(tty.st))
-	close(tty.closeC)
+	tty.sigwinchCtxCancel()
 	close(tty.ws)
 	return nil
 }

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -362,6 +362,6 @@ func (tty *TTY) raw() (func() error, error) {
 	}, nil
 }
 
-func (tty *TTY) sigwinch() chan WINSIZE {
+func (tty *TTY) sigwinch() <-chan WINSIZE {
 	return tty.ws
 }

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	isatty "github.com/mattn/go-isatty"
+	"github.com/mattn/go-isatty"
 )
 
 const (


### PR DESCRIPTION
if the term is resized when `ReadString` is being called and no one is reading form ws, we get a `panic: send on closed channel`.

It could make sense to poll getconsolescreenbufferinfo calls instead of this:

something started from the `sigwinch()` func