### PR TITLE
enable control flow; without this ctrl-s and ctrl-q are not respected

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -41,7 +41,7 @@ func open() (*TTY, error) {
 		return nil, err
 	}
 	newios := tty.termios
-	newios.Iflag &^= syscall.ISTRIP | syscall.INLCR | syscall.ICRNL | syscall.IGNCR | syscall.IXON | syscall.IXOFF
+	newios.Iflag &^= syscall.ISTRIP | syscall.INLCR | syscall.ICRNL | syscall.IGNCR | syscall.IXOFF
 	newios.Lflag &^= syscall.ECHO | syscall.ICANON /*| syscall.ISIG*/
 	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(tty.in.Fd()), ioctlWriteTermios, uintptr(unsafe.Pointer(&newios)), 0, 0, 0); err != 0 {
 		return nil, err


### PR DESCRIPTION
Hi! Having the IXON flag as part of this bitmask has caused the following issue for me:

https://github.com/hashicorp/packer/issues/8222

This PR solves the issue for me, but I'm also wondering more generally why you're overriding the termios flags by default instead of keeping them how they already were during the program run (I do not claim to be a termios expert, so there's probably a very good reason).  Another possibility that I'd be happy to implement if you're interested would to be to add some parameters to the Open call that determines what iflags to set, if you think that's a better solution.