### PR TITLE
adds OpenDevice(path string)

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -7,7 +7,11 @@ import (
 )
 
 func Open() (*TTY, error) {
-	return open()
+	return open("/dev/tty")
+}
+
+func OpenDevice(path string) (*TTY, error) {
+	return open(path)
 }
 
 func (tty *TTY) Raw() (func() error, error) {

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -21,17 +21,17 @@ type TTY struct {
 	ss      chan os.Signal
 }
 
-func open() (*TTY, error) {
+func open(path string) (*TTY, error) {
 	tty := new(TTY)
 
-	in, err := os.Open("/dev/tty")
+	in, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	tty.in = in
 	tty.bin = bufio.NewReader(in)
 
-	out, err := os.OpenFile("/dev/tty", syscall.O_WRONLY, 0)
+	out, err := os.OpenFile(path, syscall.O_WRONLY, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -4,8 +4,8 @@ package tty
 
 import (
 	"context"
-	"os"
 	"errors"
+	"os"
 	"syscall"
 	"unsafe"
 


### PR DESCRIPTION
I modified the code so the TTY is not hard coded. That way it is possible to use go-tty to access any tty (in my case, I needed it to access a serial console).

I didn't test it extensively, but so far, so good.