### PR TITLE
Fix: the first key after terminal-window activated was input twice.

### DIFF
--- a/tty_windows.go
+++ b/tty_windows.go
@@ -235,7 +235,9 @@ func (tty *TTY) readRune() (rune, error) {
 		if kr.keyDown == 0 {
 			if kr.unicodeChar != 0 && tty.readNextKeyUp {
 				tty.readNextKeyUp = false
-				return rune(kr.unicodeChar), nil
+				if 0x2000 <= kr.unicodeChar && kr.unicodeChar < 0x3000 {
+					return rune(kr.unicodeChar), nil
+				}
 			}
 		} else {
 			if kr.controlKeyState&altPressed != 0 && kr.unicodeChar > 0 {


### PR DESCRIPTION
I found that my last patch #38 for go-tty has caused a new problem from https://github.com/zetamatta/nyagos/issues/393 .

We can see the problem by this operation.

1.  Exec `go run _example\readline.go`
2.  Type ALT-TAB to focus the other Window (for example ,  Windows Explorer )
3.  Type ALT-TAB to focus the Terminal Window that `go run _example\readline.go` is running.
4.  Type `a` key.
5.  We will see two characters `aa`  input in the terminal that `go run _example\readline.go` is running.

I made another patch to reduce the bad influence of #38 .
( I am sorry that it is not an essential solution but just a workaround )

Would you please merge it , @mattn ?
