### PR TITLE
UPDATE package_version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/mattn/go-tty
 
-go 1.14
+go 1.18
 
 require (
 	github.com/mattn/go-colorable v0.1.4
 	github.com/mattn/go-isatty v0.0.10
 	github.com/mattn/go-runewidth v0.0.7
-	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e
+	golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704
 )

--- a/go.sum
+++ b/go.sum
@@ -7,5 +7,5 @@ github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+tw
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
-golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704 h1:Y7NOhdqIOU8kYI7BxsgL38d0ot0raxvcW+EMQU2QrT4=
+golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
本package を使用したところ、下記のようなエラーが出力され、実行できませんでした。
```
# golang.org/x/sys/unix
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
../../goPath/pkg/mod/golang.org/x/sys@v0.0.0-20191120155948-bd437916bb0e/unix/zsyscall_darwin_amd64.go:121:3: too many errors
```

go 1.18 で実行するには、golang.org/x/sys/unix のバージョンを新しくする必要があるとの記載を見つけたため、最新のバージョンをimport したプルリクエストを作成させていただきました。
https://stackoverflow.com/questions/71507321/go-1-18-build-error-on-mac-unix-syscall-darwin-1-13-go253-golinkname-mus

