### PR TITLE
Numbers of columns and lines were swapped at not Windows-OS

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -79,7 +79,7 @@ func (tty *TTY) sizePixel() (int, int, int, int, error) {
 	if err != nil {
 		return -1, -1, -1, -1, err
 	}
-	return int(ws.Row), int(ws.Col), int(ws.Xpixel), int(ws.Ypixel), nil
+	return int(ws.Col), int(ws.Row), int(ws.Xpixel), int(ws.Ypixel), nil
 }
 
 func (tty *TTY) input() *os.File {


### PR DESCRIPTION
@mattn :

Number of columns and lines of the terminal at not Windows-OS look to be swapped on #45 .

Would you merge my patch if no problems are found ?

( See also [Linux のターミナルでウィンドウの幅が正しく認識されていない？ · Issue #1 · hymkor/go-multiline-ny](https://github.com/hymkor/go-multiline-ny/issues/1) )