### PR TITLE
Fix AltGr backslashes on Windows

### DIFF
--- a/tty_windows.go
+++ b/tty_windows.go
@@ -249,7 +249,11 @@ func (tty *TTY) readRune() (rune, int, error) {
 				}
 			}
 		} else {
-			if kr.controlKeyState&altPressed != 0 && kr.unicodeChar > 0 {
+			// AltGr is reported by Windows as Left-Ctrl + Right-Alt. On many
+			// keyboard layouts (e.g. German, French, Belgian) characters such as
+			// backslash are produced with AltGr. Only treat Alt as an ESC prefix
+			// when Ctrl is not also held, otherwise AltGr characters get dropped.
+			if kr.controlKeyState&altPressed != 0 && kr.controlKeyState&ctrlPressed == 0 && kr.unicodeChar > 0 {
 				tty.rs = []rune{rune(kr.unicodeChar)}
 				return rune(0x1b), 1, nil
 			}


### PR DESCRIPTION
On many keyboard layouts (e.g. German, French, Belgian), characters such as
backslash are produced with AltGr. Windows reports AltGr as Left-Ctrl +
Right-Alt. The existing code treated any Alt keypress as an ESC prefix, which
caused AltGr characters to be dropped.

This fix only treats Alt as an ESC prefix when Ctrl is **not** also held, so
AltGr combinations are passed through correctly.